### PR TITLE
Initial grpc support

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,10 @@
 {:paths ["src" "resources"]
  :deps {org.clojure/clojure {:mvn/version "1.10.1"}
         com.google.protobuf/protobuf-java {:mvn/version "3.13.0"}
-        camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.1"}}
+        camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.1"}
+        io.grpc/grpc-core {:mvn/version "1.32.1"}
+        io.grpc/grpc-stub {:mvn/version "1.32.1"}
+        io.grpc/grpc-protobuf {:mvn/version "1.32.1"}}
  :aliases
  {;; Protobuf building from source
   :sample {:extra-paths ["classes"]}

--- a/src/defteron/grpc.clj
+++ b/src/defteron/grpc.clj
@@ -1,0 +1,45 @@
+(ns defteron.grpc
+  (:require [camel-snake-kebab.core :as csk]
+            [defteron.core :as d]
+            [clojure.string :as str])
+  (:import
+    (io.grpc Server
+             Channel
+             ServerMethodDefinition
+             MethodDescriptor
+             BindableService)
+    (io.grpc.protobuf ProtoMethodDescriptorSupplier)))
+
+(def ^:private dcl (clojure.lang.DynamicClassLoader.))
+(def ^:private svc-catalog (atom {}))
+
+(defn introspect-svc [grpc-package svc]
+  (into {}
+      (comp (map (fn [^ServerMethodDefinition method] (.getMethodDescriptor method)))
+            (map (fn [^MethodDescriptor descr]
+                   (let [method-descr (.getMethodDescriptor
+                                        ^ProtoMethodDescriptorSupplier (.getSchemaDescriptor descr))]
+                     [(-> (.getFullMethodName descr) (str/split  #"/") (last) (csk/->kebab-case-keyword))
+                    {:input (.loadClass ^ClassLoader dcl (str grpc-package "." (.getFullName (.getInputType method-descr))))
+                     :output (.loadClass ^ClassLoader dcl (str grpc-package "." (.getFullName (.getOutputType method-descr))))}]))))
+      (seq (.getMethods svc))))
+
+
+(defn register-service-description [grpc-package svc]
+  (let [bind (.bindService ^BindableService svc)
+        svc-descr (.getServiceDescriptor bind)]
+    (swap! svc-catalog assoc (.getName svc-descr) (introspect-svc grpc-package bind))))
+
+(defn new-client [klazz channel]
+  ;; TODO Perform reflections on instantiation only
+  (let [client (.invoke (.getMethod klazz "newBlockingStub" (into-array Class [Channel]))
+                        nil
+                        (into-array Object [(channel)]))
+        service-name (.get (.getField klazz "SERVICE_NAME") klazz)]
+    (fn [method data]
+      (let [input (get-in @svc-catalog [service-name method :input])]
+        (d/proto->map (.invoke (.getMethod (.getClass client)
+                                           (csk/->camelCaseString method)
+                                           (into-array Class [input]))
+                               client
+                               (into-array Object [(d/map->proto input data)])))))))


### PR DESCRIPTION
This adds a gRPC wrapper for defteron.

It makes sense to have this on the same library as both are using the same underlying mechanisms most likely it will be used for the same reasons.

However, it is completely possible to split in the future to separate jars as well. For now, we'll bake it in and make sure it's coherent.