### PR TITLE
Improve defteron {,de}serialization

### DIFF
--- a/bench/bench/defteron.clj
+++ b/bench/bench/defteron.clj
@@ -1,5 +1,7 @@
 (ns bench.defteron
-  (:require [defteron.core :refer [map->proto keyword->proto]])
+  (:require [defteron.core :refer [proto->map
+                                   map->proto
+                                   keyword->proto]])
   (:import (defteron Proto$Header Proto$Size)))
 
 (defn serialize-enum-only []
@@ -9,4 +11,7 @@
 (defn serialize-msg []
   (.toByteArray (map->proto Proto$Header {:msg-size :defteron.Size/large
                                           :data "Some data"
-                                          :meta ["a" "really" "short" "list"]})) )
+                                          :meta ["a" "really" "short" "list"]})))
+
+(defn deserialize-msg [msg]
+  (proto->map msg))

--- a/bench/bench/defteron.clj
+++ b/bench/bench/defteron.clj
@@ -6,10 +6,10 @@
 
 (defn serialize-enum-only []
   (.toByteArray (.build (doto (Proto$Header/newBuilder)
-                          (.setMsgSize (keyword->proto Proto$Size :defteron.Size/large))))))
+                          (.setMsgSize (keyword->proto Proto$Size :defteron.size/large))))))
 
 (defn serialize-msg []
-  (.toByteArray (map->proto Proto$Header {:msg-size :defteron.Size/large
+  (.toByteArray (map->proto Proto$Header {:msg-size :defteron.size/large
                                           :data "Some data"
                                           :meta ["a" "really" "short" "list"]})))
 

--- a/bench/bench/defteron.clj
+++ b/bench/bench/defteron.clj
@@ -1,0 +1,12 @@
+(ns bench.defteron
+  (:require [defteron.core :refer [map->proto keyword->proto]])
+  (:import (defteron Proto$Header Proto$Size)))
+
+(defn serialize-enum-only []
+  (.toByteArray (.build (doto (Proto$Header/newBuilder)
+                          (.setMsgSize (keyword->proto Proto$Size :defteron.Size/large))))))
+
+(defn serialize-msg []
+  (.toByteArray (map->proto Proto$Header {:msg-size :defteron.Size/large
+                                          :data "Some data"
+                                          :meta ["a" "really" "short" "list"]})) )

--- a/bench/bench/native.clj
+++ b/bench/bench/native.clj
@@ -1,0 +1,11 @@
+(ns bench.native
+  (:import (defteron Proto$Header Proto$Size)))
+
+(defn serialize-enum-only []
+  (.toByteArray (.build (doto (Proto$Header/newBuilder)
+                          (.setMsgSize Proto$Size/large)))))
+(defn serialize-msg []
+  (.toByteArray (.build (doto (Proto$Header/newBuilder)
+                          (.setMsgSize Proto$Size/large)
+                          (.setData "Some data")
+                          (.addAllMeta ["a" "really" "short" "list"])))))

--- a/bench/bench/native.clj
+++ b/bench/bench/native.clj
@@ -9,3 +9,11 @@
                           (.setMsgSize Proto$Size/large)
                           (.setData "Some data")
                           (.addAllMeta ["a" "really" "short" "list"])))))
+
+(defn deserialize-msg [msg]
+  ;; Not necessarily a fair comparison,
+  ;; since bean will produce a different result,
+  ;; but I could see bean being used in production
+  ;; so it should be "ok" to check against something
+  ;; being used the same way, while not producing the same result.
+  (bean msg))

--- a/bench/bench/runner.clj
+++ b/bench/bench/runner.clj
@@ -1,0 +1,16 @@
+(ns bench.runner
+  (:require [criterium.core :as crit]
+            [bench.defteron :as lib]
+            [bench.native :as native])
+  (:gen-class))
+
+
+(defn -main []
+  (set! *warn-on-reflection* true)
+  (println ::msg)
+  (crit/report-result (crit/quick-benchmark (lib/serialize-msg) {}))
+  (crit/report-result (crit/quick-benchmark (native/serialize-msg) {}))
+
+  (println ::enum)
+  (crit/report-result (crit/quick-benchmark (lib/serialize-enum-only) {}))
+  (crit/report-result (crit/quick-benchmark (native/serialize-enum-only) {})))

--- a/bench/bench/runner.clj
+++ b/bench/bench/runner.clj
@@ -2,8 +2,13 @@
   (:require [criterium.core :as crit]
             [bench.defteron :as lib]
             [bench.native :as native])
+  (:import (defteron Proto$Header Proto$Size))
   (:gen-class))
 
+(def base (.build (doto (Proto$Header/newBuilder)
+                    (.setMsgSize Proto$Size/large)
+                    (.setData "Some data")
+                    (.addAllMeta ["a" "really" "short" "list"]))))
 
 (defn -main []
   (set! *warn-on-reflection* true)
@@ -13,4 +18,8 @@
 
   (println ::enum)
   (crit/report-result (crit/quick-benchmark (lib/serialize-enum-only) {}))
-  (crit/report-result (crit/quick-benchmark (native/serialize-enum-only) {})))
+  (crit/report-result (crit/quick-benchmark (native/serialize-enum-only) {}))
+
+  (println ::msg)
+  (crit/report-result (crit/quick-benchmark (lib/deserialize-msg base) {}))
+  (crit/report-result (crit/quick-benchmark (native/deserialize-msg base) {})))

--- a/deps.edn
+++ b/deps.edn
@@ -5,6 +5,8 @@
  :aliases
  {;; Protobuf building from source
   :sample {:extra-paths ["classes"]}
+  :perf {:extra-paths ["bench"]
+          :extra-deps {criterium/criterium {:mvn/version "0.4.6"}}}
   :test {:extra-paths ["test"]
          :extra-deps {com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
                                                  :sha "209b64504cb3bd3b99ecfec7937b358a879f55c1"}}

--- a/src/defteron/core.clj
+++ b/src/defteron/core.clj
@@ -18,16 +18,15 @@
 (def ^:dynamic *convert-key* csk/->kebab-case-keyword)
 
 ;; clj -> Proto
+(defn- kw->proto [^Descriptors$EnumDescriptor proto-enum kw]
+  (.findValueByName proto-enum (name kw)))
 
 (defmacro keyword->proto [proto-enum kw]
   `(~(symbol (name proto-enum) "valueOf") ~(name kw)))
 
-(defn- kw->proto [^Descriptors$EnumDescriptor proto-enum kw]
-  (.findValueByName proto-enum (name kw)))
-
 (defn *clj->proto [^Message$Builder builder
-                    ^Descriptors$Descriptor fields
-                    data]
+                   ^Descriptors$Descriptor fields
+                   data]
   (.build ^Message$Builder
           (reduce (fn [^Message$Builder b [key- val-]]
                     (let [field ^Descriptors$FieldDescriptor (.findFieldByName fields (csk/->snake_case_string key-))]
@@ -59,9 +58,9 @@
 (defn proto->keyword
   "Returns a keyword representation of the proto enum object"
   [proto-enum]
-  (proto->kw (if (isa? (.getClass ^Object proto-enum) ProtocolMessageEnum) (.getValueDescriptor
-                                                                     ^ProtocolMessageEnum
-                                                                     proto-enum))))
+  (proto->kw (if (isa? (.getClass ^Object proto-enum) ProtocolMessageEnum)
+               (.getValueDescriptor
+                 ^ProtocolMessageEnum proto-enum))))
 
 (defn proto->map
   "Returns a map representation of the proto message object."

--- a/src/defteron/core.clj
+++ b/src/defteron/core.clj
@@ -67,8 +67,9 @@
   [^MessageOrBuilder proto]
   (reduce
     (fn [obj [^Descriptors$FieldDescriptor descr value]]
-      (cond->> value
-        (= Descriptors$FieldDescriptor$Type/ENUM (.getType descr)) (proto->kw)
-        true (assoc obj (*convert-key* (.getName descr)))))
+      (cond-> obj
+        (some? value) (assoc (*convert-key* (.getName descr))
+                             (cond->> value
+                               (= Descriptors$FieldDescriptor$Type/ENUM (.getType descr)) (proto->kw)))))
     {}
     (.getAllFields proto)))

--- a/src/defteron/core.clj
+++ b/src/defteron/core.clj
@@ -52,7 +52,7 @@
   (let [full-name (str/split (.getFullName proto-enum)
                              #"\.")
         value (last full-name)
-        ns- (str/join "." (butlast full-name))]
+        ns- (str/lower-case (str/join "." (butlast full-name)))]
     (keyword ns- value)))
 
 (defn proto->keyword

--- a/test/defteron/core_test.clj
+++ b/test/defteron/core_test.clj
@@ -13,10 +13,10 @@
                                 (.addAllMeta ["asdf" "qwer"])))]
 
     (testing "Enums can turn into namespaced keywords"
-      (is (= :defteron.Size/large (proto->keyword Proto$Size/large))))
+      (is (= :defteron.size/large (proto->keyword Proto$Size/large))))
 
     (testing "Messages can be turned into maps"
-      (is (= {:msg-size :defteron.Size/large
+      (is (= {:msg-size :defteron.size/large
               :data "Amazing"
               :meta ["asdf" "qwer"]}
              (proto->map sample-header))))))
@@ -28,13 +28,13 @@
                                 (.addAllMeta ["asdf" "qwer"])))]
 
     (testing "Keywords can be turned into enums"
-      (is (= (keyword->proto Proto$Size :defteron.Size/large)
+      (is (= (keyword->proto Proto$Size :defteron.size/large)
              Proto$Size/large)))
 
     (testing "Maps can be turned into messages"
       (is (= sample-header
              (map->proto  Proto$Header
-                         {:msg-size :defteron.Size/large
+                         {:msg-size :defteron.size/large
                           :data "Amazing"
                           :meta ["asdf" "qwer"]}))))))
 
@@ -43,7 +43,7 @@
                             (.setMsgSize Proto$Size/large)
                             (.setData "Amazing")
                             (.addAllMeta ["asdf" "qwer"])))
-        clj-msg {:msg-size :defteron.Size/large
+        clj-msg {:msg-size :defteron.size/large
                  :data "Amazing"
                  :meta ["asdf" "qwer"]}]
 

--- a/test/defteron/core_test.clj
+++ b/test/defteron/core_test.clj
@@ -3,6 +3,9 @@
             [defteron.core :refer :all])
   (:import (defteron Proto$Header Proto$Size)))
 
+(set! *warn-on-reflection* true)
+
+
 (deftest protobuf->clojure
   (let [sample-header (.build (doto (Proto$Header/newBuilder)
                                 (.setMsgSize Proto$Size/large)


### PR DESCRIPTION
Defteron implements a wrapper on top of protobuf (and eventually, gRPC #1), which needs to be performant *not to diverge too much from the intent of the libraries themselves*, which are performance-driven.

Therefore, any optimizations made to this library help the case of using it from clojure's POV.

The initial implementation was full of unwanted reflections (and some wanted which were not particularly needed). Solving them allowed for a nice reduction of a silly message's serialization time from ~120μs to ~10μs. Still far from native's ~600ns, but enough to celebrate for now.

Further investments in performance will be done later on as more and more usecases are implemented and tested.